### PR TITLE
Change DynamoDB billing mode to On-Demand

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,9 @@ resource "aws_s3_bucket" "state" {
 
 resource "aws_dynamodb_table" "lock" {
   name           = "${var.name_prefix}-terraform-state"
-  read_capacity  = 20
-  write_capacity = 20
+
+  billing_mode   = "PAY_PER_REQUEST"
+
   hash_key       = "LockID"
 
   attribute {


### PR DESCRIPTION
Change DynamoDB billing mode to On-Demand since the usage of Terraform is generally small and varying.