### PR TITLE
Added optional KMS key policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "aws_dynamodb_table" "lock" {
 resource "aws_kms_key" "encrypt" {
   description             = "Terraform state KMS key."
   deletion_window_in_days = 30
+  policy                  = var.kms_key_policy
   tags = merge(
     var.tags,
     {
@@ -52,4 +53,3 @@ resource "aws_kms_alias" "encrypt-alias" {
   name          = "alias/${var.name_prefix}-terraform-state-encryption-key"
   target_key_id = aws_kms_key.encrypt.key_id
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -11,3 +11,7 @@ variable "tags" {
   default     = {}
 }
 
+variable "kms_key_policy" {
+  description = "(Optional) A valid KMS policy JSON document."
+  default     = null
+}


### PR DESCRIPTION
This can be used to explicitly allow other accounts to read terraform state