### PR TITLE
Block all public access on state bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,15 @@ resource "aws_s3_bucket" "state" {
   )
 }
 
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}
+
 resource "aws_dynamodb_table" "lock" {
   name = "${var.name_prefix}-terraform-state"
 


### PR DESCRIPTION
_Block all public access_ is not enabled by default if a bucket created by Terraform.
AWS Trusted Advisor reports that as a security risk.