### PR TITLE
Relax the AWS provider constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 3.75, < 5.0"
     }
   }
 }


### PR DESCRIPTION
Our use of `aws_s3_bucket_acl` and so forth means that the minimum AWS provider version is 3.75, so we can relax the constraint to make it easier to migrate providers.