### PR TITLE
Add S3 ownership controls for new AWS defaults

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,18 @@ resource "aws_s3_bucket_versioning" "state" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "state" {
+  bucket = aws_s3_bucket.state.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "state" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.state,
+  ]
+  
   bucket = aws_s3_bucket.state.id
   acl    = "private"
 }


### PR DESCRIPTION
New "terraform state" deployments fail on "aws_s3_bucket_acl". This is because of the new S3 defaults in AWS this month. Here are suggested changes for Terraform: https://github.com/hashicorp/terraform-provider-aws/issues/28353

This should not be a breaking change, but please help me review and test the change.

Closes the following issue: https://github.com/telia-oss/terraform-aws-terraform-init/issues/17

